### PR TITLE
`helperMissing` の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -1358,7 +1358,7 @@ import (
     "github.com/fixpoint/handlebars/v3/parser"
 )
 
-fu  nc main() {
+func main() {
     source := "You know {{nothing}} John Snow"
 
     // parse template

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Handlebars for [golang](https://golang.org) with the same features as [handlebar
   - [Utilites](#utilites)
     - [`Str()`](#str)
     - [`IsTrue()`](#istrue)
+- [Hooks](#hooks)
+  - [`helperMissing`](#helpermissing)
 - [Context Functions](#context-functions)
 - [Partials](#partials)
   - [Template Partials](#template-partials)
@@ -1091,6 +1093,55 @@ It returns `false` when parameter is either:
   - `false`
 
 For all others values, `IsTrue()` returns `true`.
+
+
+## Hooks
+
+There are several places where you can hook into Handlebars function calls.
+
+
+### `helperMissing`
+
+This hook is called when a mustache or a block-statement
+
+- a simple mustache-expression is not a registered helper AND
+- is not a property of the current evaluation context.
+
+If no parameters are passed to the mustache, the default behavior is to do nothing and ignore the whole mustache expression or the whole block:
+
+For example that template:
+
+```html
+some_{{foo}}mustache
+some_{{#foo}}abc{{/foo}}block
+```
+
+Outputs:
+
+```html
+some_mustache
+some_block
+```
+
+If parameter is passed to the mustache, Handlebars with throw an exception:
+
+For example that template:
+
+```html
+{{foo bar}}
+```
+
+OR
+
+```html
+{{#foo bar}}abc{{/foo}}
+```
+
+Throws:
+
+```html
+Missing helper: "foo"
+```
 
 
 ## Context Functions

--- a/README.md
+++ b/README.md
@@ -1297,7 +1297,6 @@ These handlebars features are currently NOT implemented:
 
 - raw block content is not passed as a parameter to helper
 - `blockHelperMissing` - helper called when a helper can not be directly resolved
-- `helperMissing` - helper called when a potential helper expression was not found
 - `@contextPath` - value set in `trackIds` mode that records the lookup path for the current context
 - `@level` - log level
 

--- a/eval.go
+++ b/eval.go
@@ -699,7 +699,9 @@ func (v *evalVisitor) callHelperMissing(node *ast.Expression) interface{} {
 func (v *evalVisitor) callHelperMissingFunc(name string, funcVal reflect.Value, options *Options) reflect.Value {
 	params := options.Params()
 
-	args := make([]reflect.Value, len(params)+1)
+	args := make([]reflect.Value, len(params)+2)
+	args[0] = reflect.ValueOf(name)
+	args[1] = reflect.ValueOf(options)
 
 	// check and collect arguments
 	funcType := funcVal.Type()
@@ -709,9 +711,8 @@ func (v *evalVisitor) callHelperMissingFunc(name string, funcVal reflect.Value, 
 		if !arg.IsValid() {
 			arg = reflect.Zero(argType)
 		}
-		args[i] = arg
+		args[i+2] = arg
 	}
-	args[len(args)-1] = reflect.ValueOf(options)
 
 	result := funcVal.Call(args)
 

--- a/eval.go
+++ b/eval.go
@@ -651,7 +651,7 @@ func (v *evalVisitor) callFunc(name string, funcVal reflect.Value, options *Opti
 	return result[0]
 }
 
-// callHelper invoqs helper function for given expression node
+// callHelper invokes helper function for given expression node
 func (v *evalVisitor) callHelper(name string, helper reflect.Value, node *ast.Expression) interface{} {
 	result := v.callFunc(name, helper, v.helperOptions(node))
 	if !result.IsValid() {

--- a/eval_test.go
+++ b/eval_test.go
@@ -101,6 +101,29 @@ var evalTests = []Test{
 		`Length: 5`,
 	},
 	// @todo Test with a "../../path" (depth 2 path) while context is only depth 1
+	{
+		"if a context is not found, custom helperMissing is used",
+		"{{hello}} {{link_to world}}",
+		map[string]interface{}{"hello": "Hello", "world": "world"},
+		nil,
+		map[string]interface{}{"helperMissing": func(name string, options *Options, args ...interface{}) SafeString {
+			mesg := args[0].(string)
+			return SafeString("<a>" + mesg + "</a>")
+		}},
+		nil,
+		"Hello <a>world</a>",
+	},
+	{
+		"if a value is not found, custom helperMissing is used",
+		"{{hello}} {{link_to}}",
+		map[string]interface{}{"hello": "Hello", "world": "world"},
+		nil,
+		map[string]interface{}{"helperMissing": func(name string, options *Options, args ...interface{}) SafeString {
+			return SafeString("<a>winning</a>")
+		}},
+		nil,
+		"Hello <a>winning</a>",
+	},
 }
 
 func TestEval(t *testing.T) {
@@ -130,6 +153,15 @@ var evalErrors = []Test{
 		map[string]interface{}{"foo": func() (string, bool, string) { return "foo", true, "bar" }},
 		nil, nil, nil,
 		"Helper function must return a string or a SafeString",
+	},
+	{
+		"if a context is not found, helperMissing is used",
+		"{{hello}} {{link_to world}}",
+		nil,
+		nil,
+		nil,
+		nil,
+		`Missing helper: "link_to"`,
 	},
 }
 

--- a/eval_test.go
+++ b/eval_test.go
@@ -102,6 +102,15 @@ var evalTests = []Test{
 	},
 	// @todo Test with a "../../path" (depth 2 path) while context is only depth 1
 	{
+		"if a block is not found and without params, helperMissing is used",
+		"some_{{#foo}}abc{{/foo}}block",
+		nil,
+		nil,
+		nil,
+		nil,
+		"some_block",
+	},
+	{
 		"if a context is not found, custom helperMissing is used",
 		"{{hello}} {{link_to world}}",
 		map[string]interface{}{"hello": "Hello", "world": "world"},
@@ -162,6 +171,15 @@ var evalErrors = []Test{
 		nil,
 		nil,
 		`Missing helper: "link_to"`,
+	},
+	{
+		"if a block is not found, helperMissing is used",
+		"{{#foo bar}}abc{{/foo}}",
+		nil,
+		nil,
+		nil,
+		nil,
+		`Missing helper: "foo"`,
 	},
 }
 

--- a/helper.go
+++ b/helper.go
@@ -403,18 +403,11 @@ func equalHelper(a interface{}, b interface{}, options *Options) interface{} {
 //
 
 // #helperMissing helper
-func helperMissingHelper(args ...interface{}) interface{} {
-	options, ok := args[len(args)-1].(*Options)
-	if !ok {
-		return nil
-	}
-	if len(args) == 1 {
+func helperMissingHelper(name string, options *Options, args ...interface{}) interface{} {
+	if len(args) == 0 {
 		// A missing field in a {{foo}} construct
 		return nil
 	}
-	node, ok := options.eval.curNode.(*ast.Expression)
-	if ok {
-		options.eval.errorf(`Missing helper: "%s"`, node.HelperName())
-	}
+	options.eval.errorf(`Missing helper: "%s"`, name)
 	return nil
 }

--- a/internal/handlebarsjs/helpers_test.go
+++ b/internal/handlebarsjs/helpers_test.go
@@ -562,13 +562,38 @@ var helpersTests = []Test{
 		nil,
 		"NOT PRINTING",
 	},
-
-	// @todo "helperMissing - if a context is not found, helperMissing is used" throw error
-
-	// @todo "helperMissing - if a context is not found, custom helperMissing is used"
-
-	// @todo "helperMissing - if a value is not found, custom helperMissing is used"
-
+	{
+		"if a context is not found, helperMissing is used",
+		"{{hello}} {{link_to world}}",
+		nil,
+		nil,
+		nil,
+		nil,
+		`Missing helper: "link_to"`,
+	},
+	{
+		"if a context is not found, custom helperMissing is used",
+		"{{hello}} {{link_to world}}",
+		map[string]interface{}{"hello": "Hello", "world": "world"},
+		nil,
+		map[string]interface{}{"helperMissing": func(name string, options *handlebars.Options, args ...interface{}) handlebars.SafeString {
+			mesg := args[0].(string)
+			return handlebars.SafeString("<a>" + mesg + "</a>")
+		}},
+		nil,
+		"Hello <a>world</a>",
+	},
+	{
+		"if a value is not found, custom helperMissing is used",
+		"{{hello}} {{link_to}}",
+		map[string]interface{}{"hello": "Hello", "world": "world"},
+		nil,
+		map[string]interface{}{"helperMissing": func(name string, options *handlebars.Options, args ...interface{}) handlebars.SafeString {
+			return handlebars.SafeString("<a>winning</a>")
+		}},
+		nil,
+		"Hello <a>winning</a>",
+	},
 	{
 		"block helpers can take an optional hash with booleans (1)",
 		`{{#goodbye cruel="CRUEL" print=false}}world{{/goodbye}}`,

--- a/internal/handlebarsjs/helpers_test.go
+++ b/internal/handlebarsjs/helpers_test.go
@@ -563,38 +563,6 @@ var helpersTests = []Test{
 		"NOT PRINTING",
 	},
 	{
-		"if a context is not found, helperMissing is used",
-		"{{hello}} {{link_to world}}",
-		nil,
-		nil,
-		nil,
-		nil,
-		`Missing helper: "link_to"`,
-	},
-	{
-		"if a context is not found, custom helperMissing is used",
-		"{{hello}} {{link_to world}}",
-		map[string]interface{}{"hello": "Hello", "world": "world"},
-		nil,
-		map[string]interface{}{"helperMissing": func(name string, options *handlebars.Options, args ...interface{}) handlebars.SafeString {
-			mesg := args[0].(string)
-			return handlebars.SafeString("<a>" + mesg + "</a>")
-		}},
-		nil,
-		"Hello <a>world</a>",
-	},
-	{
-		"if a value is not found, custom helperMissing is used",
-		"{{hello}} {{link_to}}",
-		map[string]interface{}{"hello": "Hello", "world": "world"},
-		nil,
-		map[string]interface{}{"helperMissing": func(name string, options *handlebars.Options, args ...interface{}) handlebars.SafeString {
-			return handlebars.SafeString("<a>winning</a>")
-		}},
-		nil,
-		"Hello <a>winning</a>",
-	},
-	{
 		"block helpers can take an optional hash with booleans (1)",
 		`{{#goodbye cruel="CRUEL" print=false}}world{{/goodbye}}`,
 		nil, nil,


### PR DESCRIPTION
https://handlebarsjs.com/guide/hooks.html#helpermissing に従って、未登録のヘルパー使用時の処理として `helperMissing` を実装しました。
デフォルトの挙動としては以下、

- `{{foo}}` のように存在しないフィールドパス指定の場合:
    - 何も出力しない
- `{{foo bar}}` のように存在しないヘルパーの場合:
    - ランタイムエラーとして `Missing helper: "foo"` を出力
- `{{#foo}}...{{/foo}}` や `{{#foo bar}}...{{/foo}}` のようなブロック構文でも同様
    - (`{{#foo}}...{{/foo}}` の場合は、中の `...` も含めて出力しない

**備考**

`go test`, `go fmt` が通る & 差分ないことは確認済み。